### PR TITLE
Add x-product-id and handles missing pageOrder

### DIFF
--- a/servidor/platforms/hotmart.py
+++ b/servidor/platforms/hotmart.py
@@ -229,6 +229,11 @@ class HotmartScraper(PlatformScraper):
         #     'club': product_subdomain
         # })
 
+        # Inconditionally adds a new HTTP header 'x-product-id' that seems to be required as of January 2025
+        self.scraper.session.headers.update({
+            'x-product-id': f'{int(desired_course["id"])}'
+        })
+
         course_data = None
 
         if not USE_NEW:
@@ -241,10 +246,17 @@ class HotmartScraper(PlatformScraper):
         sorted_modules = sorted(product_info["modules"], key=lambda x: x["moduleOrder"])
         for i, module in enumerate(sorted_modules, start=1):
             module["moduleOrder"] = i
-            sorted_pages = sorted(module["pages"], key=lambda x: x["pageOrder"])
-            for j, page in enumerate(sorted_pages, start=1):
-                page["pageOrder"] = j
-            module["pages"] = sorted_pages
+            try:
+                sorted_pages = sorted(module["pages"], key=lambda x: x["pageOrder"])
+                for j, page in enumerate(module["pages"], start=1):
+                    page["pageOrder"] = j
+                module["pages"] = sorted_pages
+            except KeyError:
+                for j, page in enumerate(module["pages"], start=1):
+                    page["pageOrder"] = j
+            finally:
+                if not module["pages"]:
+                    module["pages"] = []
 
         product_info["modules"] = sorted_modules
         # print('*'*100)


### PR DESCRIPTION
Apparently, sometime since the last public version was released, the ember platform has changed a few bits and bobs around their API.

The request that handles scraping more info about the modules was returning an HTTP 400 request due to a missing header: `x-product-id`. Since that information was already saved, indexed and easy to grab, I patched the request headers to include it by default. At worst it should be ignored if not required, otherwise it currently satisfies the request.

Also, it seems that either in their revised API responses or in the case of the particular course I was attempting to download, the `sorted_modules` child element `pages` did not have a `pageOrder` attribute in any of its instances. So I handled a dirty fix that attempts to work as it used to and if the key is non-existent, then it just adds an ordered index similar to what you had done.

The implementation was the bare minimal to get it working again. I'm glad to make/improve any changes the maintainers find useful. Thanks for the amazing work so far and the public service of allowing time-deprived people to preserve their rights to use purchased contents such as courses from HM.